### PR TITLE
fix project.resource

### DIFF
--- a/lib/transifex/project.rb
+++ b/lib/transifex/project.rb
@@ -16,7 +16,7 @@ module Transifex
     end
 
     def resource(resource_slug)
-      resource = client.get("/project/#{@slug}/resources/#{resource_slug}")
+      resource = client.get("/project/#{@slug}/resource/#{resource_slug}")
       Transifex::Resource.new(@slug, resource).tap {|r| r.client = client }
     end
   end


### PR DESCRIPTION
Per http://support.transifex.com/customer/portal/articles/1009524-resource-api

URL format is `/project/<project_slug>/resource/<resource_slug>/` , with a singular "resource".
