### PR TITLE
bump faraday to make it compatible with private repo

### DIFF
--- a/transifex-ruby.gemspec
+++ b/transifex-ruby.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |s|
   s.authors       = ['Toru Maesaka', 'Jason Barnabe']
   s.email         = ['toru@tmaesaka.com', 'jason.barnabe@gmail.com']
 
-  s.add_dependency 'faraday', '~> 0.8.0'
+  s.add_dependency 'faraday', '>= 0.8.0'
   s.add_dependency 'faraday_middleware', '~> 0.9.0'
   s.add_dependency 'hashie', '~> 1.2.0'
 


### PR DESCRIPTION
Hi everybody,
I'd need a bump to the faraday version in order to make this gem compatible with a private repo from my company.
I've run the tests and they pass with no issue.